### PR TITLE
Add octonion-based GPT model

### DIFF
--- a/model_octonion.py
+++ b/model_octonion.py
@@ -1,0 +1,208 @@
+"""
+Octonion-based GPT model inspired by model.py.
+This version treats the embedding dimension as groups of 8 real-valued
+components representing octonions. Linear layers are replaced by
+OctonionLinear which applies the same real weight matrix to each of the
+8 components, avoiding mixing between octonion parts. The feed-forward
+network therefore becomes a linear combination of octonions rather than
+scalars.
+"""
+
+import math
+from dataclasses import dataclass
+
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+
+
+class LayerNorm(nn.Module):
+    """ LayerNorm but with an optional bias. """
+
+    def __init__(self, ndim, bias):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(ndim))
+        self.bias = nn.Parameter(torch.zeros(ndim)) if bias else None
+
+    def forward(self, input):
+        return F.layer_norm(input, self.weight.shape, self.weight, self.bias, 1e-5)
+
+
+class OctonionLinear(nn.Module):
+    """Linear layer operating on groups of 8 features as octonions.
+
+    The same real-valued weight matrix is applied to each component of the
+    octonion independently, so components never mix.
+    """
+
+    def __init__(self, in_octonions, out_octonions, bias=True):
+        super().__init__()
+        self.in_oct = in_octonions
+        self.out_oct = out_octonions
+        self.weight = nn.Parameter(torch.empty(out_octonions, in_octonions))
+        if bias:
+            self.bias = nn.Parameter(torch.zeros(out_octonions, 8))
+        else:
+            self.bias = None
+
+    def forward(self, x):
+        # x shape: (..., in_octonions * 8)
+        orig_shape = x.shape
+        x = x.view(-1, self.in_oct, 8)  # merge batch dims
+        y = torch.einsum('bic,oi->boc', x, self.weight)
+        if self.bias is not None:
+            y = y + self.bias
+        y = y.view(*orig_shape[:-1], self.out_oct * 8)
+        return y
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        assert config.n_embd % config.n_head == 0
+        assert config.n_embd % 8 == 0, "n_embd must be divisible by 8"
+        n_oct = config.n_embd // 8
+        self.c_attn = OctonionLinear(n_oct, 3 * n_oct, bias=config.bias)
+        self.c_proj = OctonionLinear(n_oct, n_oct, bias=config.bias)
+        self.attn_dropout = nn.Dropout(config.dropout)
+        self.resid_dropout = nn.Dropout(config.dropout)
+        self.n_head = config.n_head
+        self.n_embd = config.n_embd
+        self.dropout = config.dropout
+        self.flash = hasattr(torch.nn.functional, 'scaled_dot_product_attention')
+        if not self.flash:
+            print("WARNING: using slow attention. Flash Attention requires PyTorch >= 2.0")
+            self.register_buffer(
+                "bias",
+                torch.tril(torch.ones(config.block_size, config.block_size))
+                .view(1, 1, config.block_size, config.block_size),
+            )
+
+    def forward(self, x):
+        B, T, C = x.size()
+        q, k, v = self.c_attn(x).split(self.n_embd, dim=2)
+        k = k.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)
+        q = q.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)
+        v = v.view(B, T, self.n_head, C // self.n_head).transpose(1, 2)
+
+        if self.flash:
+            y = torch.nn.functional.scaled_dot_product_attention(
+                q, k, v, attn_mask=None, dropout_p=self.dropout if self.training else 0, is_causal=True
+            )
+        else:
+            att = (q @ k.transpose(-2, -1)) * (1.0 / math.sqrt(k.size(-1)))
+            att = att.masked_fill(self.bias[:, :, :T, :T] == 0, float('-inf'))
+            att = F.softmax(att, dim=-1)
+            att = self.attn_dropout(att)
+            y = att @ v
+        y = y.transpose(1, 2).contiguous().view(B, T, C)
+        y = self.resid_dropout(self.c_proj(y))
+        return y
+
+
+class MLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        assert config.n_embd % 8 == 0, "n_embd must be divisible by 8"
+        n_oct = config.n_embd // 8
+        self.c_fc = OctonionLinear(n_oct, 4 * n_oct, bias=config.bias)
+        self.gelu = nn.GELU()
+        self.c_proj = OctonionLinear(4 * n_oct, n_oct, bias=config.bias)
+        self.dropout = nn.Dropout(config.dropout)
+
+    def forward(self, x):
+        x = self.c_fc(x)
+        x = self.gelu(x)
+        x = self.c_proj(x)
+        x = self.dropout(x)
+        return x
+
+
+class Block(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.ln_1 = LayerNorm(config.n_embd, bias=config.bias)
+        self.attn = CausalSelfAttention(config)
+        self.ln_2 = LayerNorm(config.n_embd, bias=config.bias)
+        self.mlp = MLP(config)
+
+    def forward(self, x):
+        x = x + self.attn(self.ln_1(x))
+        x = x + self.mlp(self.ln_2(x))
+        return x
+
+
+@dataclass
+class GPTConfig:
+    block_size: int = 1024
+    vocab_size: int = 50304
+    n_layer: int = 12
+    n_head: int = 12
+    n_embd: int = 768
+    dropout: float = 0.0
+    bias: bool = True
+
+
+class OctonionGPT(nn.Module):
+    def __init__(self, config: GPTConfig):
+        super().__init__()
+        assert config.vocab_size is not None
+        assert config.block_size is not None
+        assert config.n_embd % 8 == 0, "n_embd must be divisible by 8"
+        self.config = config
+        self.transformer = nn.ModuleDict(
+            dict(
+                wte=nn.Embedding(config.vocab_size, config.n_embd),
+                wpe=nn.Embedding(config.block_size, config.n_embd),
+                drop=nn.Dropout(config.dropout),
+                h=nn.ModuleList([Block(config) for _ in range(config.n_layer)]),
+                ln_f=LayerNorm(config.n_embd, bias=config.bias),
+            )
+        )
+        self.lm_head = nn.Linear(config.n_embd, config.vocab_size, bias=False)
+        self.transformer.wte.weight = self.lm_head.weight
+
+        self.apply(self._init_weights)
+        for pn, p in self.named_parameters():
+            if pn.endswith('c_proj.weight'):
+                torch.nn.init.normal_(p, mean=0.0, std=0.02 / math.sqrt(2 * config.n_layer))
+        print("number of parameters: %.2fM" % (self.get_num_params() / 1e6,))
+
+    def get_num_params(self, non_embedding=True):
+        n_params = sum(p.numel() for p in self.parameters())
+        if non_embedding:
+            n_params -= self.transformer.wpe.weight.numel()
+        return n_params
+
+    def _init_weights(self, module):
+        if isinstance(module, (nn.Linear, OctonionLinear)):
+            torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
+            if module.bias is not None:
+                torch.nn.init.zeros_(module.bias)
+        elif isinstance(module, nn.Embedding):
+            torch.nn.init.normal_(module.weight, mean=0.0, std=0.02)
+
+    def forward(self, idx, targets=None):
+        device = idx.device
+        b, t = idx.size()
+        assert t <= self.config.block_size
+        pos = torch.arange(0, t, dtype=torch.long, device=device)
+
+        tok_emb = self.transformer.wte(idx)
+        pos_emb = self.transformer.wpe(pos)
+        x = self.transformer.drop(tok_emb + pos_emb)
+        for block in self.transformer.h:
+            x = block(x)
+        x = self.transformer.ln_f(x)
+
+        if targets is not None:
+            logits = self.lm_head(x)
+            loss = F.cross_entropy(logits.view(-1, logits.size(-1)), targets.view(-1), ignore_index=-1)
+        else:
+            logits = self.lm_head(x[:, [-1], :])
+            loss = None
+        return logits, loss
+
+    def crop_block_size(self, block_size):
+        assert block_size <= self.config.block_size
+        self.config.block_size = block_size


### PR DESCRIPTION
## Summary
- add OctonionLinear layer operating on 8-channel octonion groups
- build OctonionGPT model using octonion-aware attention and MLP

## Testing
- `python -m py_compile model_octonion.py`
- `python - <<'PY'
from model_octonion import OctonionGPT, GPTConfig
m = OctonionGPT(GPTConfig())
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a83a184d40832998fd307b301cf95c